### PR TITLE
Feature/configure auto index

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ The following Elasticsearch properties can be configured through the plugin conf
 *   **scriptFile** [required by the *load* goal]
     > a list of commands to be executed to provision the Elasticsearch cluster. See the [load.script](#load.script) section for details.
 
+*   **autoCreateIndex** [optional]
+    > configuration of automatic index creation (defaults to _false_).
+
 Include the following in the pom.xml file and modify the configuration as needed:
 
         <plugin>

--- a/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/StartElasticsearchNodeMojo.java
+++ b/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/StartElasticsearchNodeMojo.java
@@ -43,6 +43,11 @@ public class StartElasticsearchNodeMojo extends AbstractElasticsearchNodeMojo {
     protected String pluginsPath;
 
     /**
+     * @parameter default-value=false
+     */
+    protected boolean autoCreateIndex;
+
+    /**
      * @parameter
      * @required
      */
@@ -56,7 +61,7 @@ public class StartElasticsearchNodeMojo extends AbstractElasticsearchNodeMojo {
 
         Settings.Builder builder = Settings.settingsBuilder()
                 .put("cluster.name", clusterName)
-                .put("action.auto_create_index", false)
+                .put("action.auto_create_index", autoCreateIndex)
                 .put("transport.tcp.port", tcpPort)
                 .put("http.port", httpPort)
                 // ES v2.0.0 requires this property; set it to the parent of the data/log dirs.

--- a/src/test/java/com/github/alexcojocaru/mojo/elasticsearch/StartElasticsearchDataMojoTest.java
+++ b/src/test/java/com/github/alexcojocaru/mojo/elasticsearch/StartElasticsearchDataMojoTest.java
@@ -52,6 +52,7 @@ public class StartElasticsearchDataMojoTest extends AbstractMojoTestCase
         HttpGet get = new HttpGet("http://localhost:" + mojo.getNode().getHttpPort());
         HttpResponse response = client.execute(get);
         assertEquals(200, response.getStatusLine().getStatusCode());
+        assertEquals(true, mojo.autoCreateIndex);
     }
 
 }

--- a/src/test/resources/goals/start/pom.xml
+++ b/src/test/resources/goals/start/pom.xml
@@ -17,6 +17,7 @@
 					<clusterName>test</clusterName>
 					<tcpPort>9300</tcpPort>
 					<httpPort>9200</httpPort>
+					<autoCreateIndex>true</autoCreateIndex>
 				</configuration>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
It should be optional to turn on automatic index creation. In some cases it's desirable to make Elasticsearch create indexes.