### PR TITLE
Add 'keepData' option to StartMojo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ The following Elasticsearch properties can be configured through the plugin conf
 *   **logsDirname** [optional]
     > the name of the directory within the *outputDirectory* (see the property above) where the Elasticsearch logs will be created;
 
+*   **keepData** [optional]
+    > whether to keep the data and log directories if they already exist (defaults to _false_);
+
 *   **configPath** [optional]
     > the path of the config directory to be used by the Elasticsearch instance; it is needed for scripting support, in which case the directory referred by the path should contains only a *scripts* directory, with the required scripts;
 

--- a/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/StartElasticsearchNodeMojo.java
+++ b/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/StartElasticsearchNodeMojo.java
@@ -24,6 +24,11 @@ public class StartElasticsearchNodeMojo extends AbstractElasticsearchNodeMojo {
     protected File outputDirectory;
 
     /**
+     * @parameter default-value="false"
+     */
+    protected boolean keepData;
+
+    /**
      * @parameter default-value="elasticsearch-data"
      */
     protected String dataDirname;
@@ -111,6 +116,11 @@ public class StartElasticsearchNodeMojo extends AbstractElasticsearchNodeMojo {
         // If the directory already exists, delete it.
         if (dir.exists())
         {
+            if (keepData)
+            {
+                return dir;
+            }
+
             try
             {
                 FileUtils.deleteDirectory(dir);
@@ -122,7 +132,7 @@ public class StartElasticsearchNodeMojo extends AbstractElasticsearchNodeMojo {
                         + dir.getAbsolutePath(), e);
             }
         }
-        
+
         // Create a new Elasticsearch directory.
         if (!dir.mkdirs())
         {

--- a/src/test/java/com/github/alexcojocaru/mojo/elasticsearch/StartElasticsearchDataMojoTest.java
+++ b/src/test/java/com/github/alexcojocaru/mojo/elasticsearch/StartElasticsearchDataMojoTest.java
@@ -10,7 +10,6 @@ import org.apache.maven.plugin.testing.AbstractMojoTestCase;
 
 import com.github.alexcojocaru.mojo.elasticsearch.NetUtil.ElasticsearchPort;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
@@ -123,16 +122,8 @@ public class StartElasticsearchDataMojoTest extends AbstractMojoTestCase
     private StatusLine createIndex(final String indexName) throws Exception
     {
         final String indexUri = getUri() + "/" + indexName;
-        HttpPut put = new HttpPut(indexUri);
-        HttpResponse response = httpClient.execute(put);
-        final StatusLine statusLine = response.getStatusLine();
-        if (statusLine.getStatusCode() >= 300) {
-            final ByteArrayOutputStream ostream = new ByteArrayOutputStream();
-            response.getEntity().writeTo(ostream);
-            System.out.println(statusLine.toString());
-            System.out.println(ostream.toString());
-        }
-        return statusLine;
+        final HttpResponse response = httpClient.execute(new HttpPut(indexUri));
+        return response.getStatusLine();
     }
 
 }


### PR DESCRIPTION
Hi, I'm trying to use the plugin together with cargo.run in order to run the site and the backing elasticsearch from maven, but I got stumped because my data kept getting deleted.

Here's a patch that adds a 'keepData' option. It's against the 1.x branch because that's what I'm using and I first want to know what you think of it before duplicating it in 'master'.