### PR TITLE
Version 5.0 with support for ES 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: java
 jdk:
-  - oraclejdk7
+  - oraclejdk8
 script: "mvn clean verify"

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
 	<groupId>com.github.alexcojocaru</groupId>
 	<artifactId>elasticsearch-maven-plugin</artifactId>
-	<version>2.3-SNAPSHOT</version>
+	<version>5.0-SNAPSHOT</version>
 	<packaging>maven-plugin</packaging>
 
 	<name>Elasticsearch Maven Plugin</name>
@@ -82,8 +82,13 @@
 		<dependency>
 			<groupId>org.elasticsearch</groupId>
 			<artifactId>elasticsearch</artifactId>
-			<version>2.0.0</version>
+			<version>5.0.0</version>
 			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.elasticsearch.plugin</groupId>
+			<artifactId>transport-netty4-client</artifactId>
+			<version>5.0.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.apache.httpcomponents</groupId>
@@ -129,9 +134,14 @@
 		</dependency>
 		<!-- required for logging support -->
 		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-			<version>1.2.17</version>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-api</artifactId>
+			<version>2.6.2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+			<version>2.6.2</version>
 		</dependency>
 	</dependencies>
 
@@ -149,7 +159,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-plugin-plugin</artifactId>
-				<version>3.2</version>
+				<version>3.5</version>
 				<configuration>
 					<goalPrefix>elasticsearch</goalPrefix>
 					<skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>

--- a/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/ElasticsearchNode.java
+++ b/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/ElasticsearchNode.java
@@ -1,12 +1,20 @@
 package com.github.alexcojocaru.mojo.elasticsearch;
 
 import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
 
 import org.apache.maven.plugin.MojoExecutionException;
+import org.elasticsearch.cli.Terminal;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.common.logging.LogConfigurator;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.env.Environment;
 import org.elasticsearch.node.Node;
-import org.elasticsearch.node.NodeBuilder;
+import org.elasticsearch.node.NodeValidationException;
+import org.elasticsearch.node.internal.InternalSettingsPreparer;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.transport.Netty4Plugin;
 
 /**
  * @author alexcojocaru
@@ -14,50 +22,56 @@ import org.elasticsearch.node.NodeBuilder;
  */
 public class ElasticsearchNode
 {
+
+    public static class PluginNode extends Node {
+        public PluginNode(Environment environment) {
+            super(environment, Collections.<Class<? extends Plugin>>singletonList(Netty4Plugin.class));
+        }
+    }
+
     private Node node;
     private int httpPort;
 
-    /**
-     * Start a local ES node with the given settings.
-     * <br>
-     * If the local node is already running prior to calling this method,
-     * an IllegalStateException will be thrown.
-     * @param settings
-     * @throws MojoExecutionException 
-     */
-    public ElasticsearchNode(Settings settings) throws MojoExecutionException
+    private ElasticsearchNode(Environment environment) throws MojoExecutionException
     {
-        // Set the node to be as lightweight as possible,
-        // at the same time being able to be discovered from an external JVM.
-        settings = Settings.settingsBuilder()
-                .put("index.number_of_shards", 1)
-                .put("index.number_of_replicas", 0)
-                .put("network.host", "127.0.0.1")
-                .put("discovery.zen.ping.timeout", "3ms")
-                .put("discovery.zen.ping.multicast.enabled", false)
-                .put("http.cors.enabled", true)
-                .put(settings)
+        httpPort = environment.settings().getAsInt("http.port", 9200);
+
+        // Must use this constructor to get proper environment initialization
+        node = new PluginNode(environment);
+
+        try {
+            node.start();
+        } catch (NodeValidationException e) {
+             throw new MojoExecutionException( "Error starting the ES node", e );
+        }
+
+        // Set the indices to be as lightweight as possible by default
+        Settings indexTemplateSettings = Settings.builder()
+                .put("number_of_shards", 1)
+                .put("number_of_replicas", 0)
                 .build();
-        
-        httpPort = settings.getAsInt("http.port", 9200);
-        
-        node = NodeBuilder.nodeBuilder().settings(settings).node();
+        getClient().admin().indices()
+                .preparePutTemplate( "lightweight_index" )
+                .setTemplate( "*" )
+                .setSettings( indexTemplateSettings )
+                .execute()
+                .actionGet();
     }
-    
+
     /**
      * Start a local ES node with default settings.
      * <br>
      * If the local node is already running prior to calling this method,
      * an IllegalStateException will be thrown.
      * @param dataPath
-     * @throws MojoExecutionException 
+     * @throws MojoExecutionException
      * @return an instance of an ElasticsearchNode
      */
     public static ElasticsearchNode start(String dataPath) throws MojoExecutionException
     {
         return start(dataPath, 9200, 9300);
     }
-    
+
     /**
      * Start a local ES node with default settings.
      * <br>
@@ -66,7 +80,7 @@ public class ElasticsearchNode
      * @param dataPath
      * @param httpPort
      * @param tcpPort
-     * @throws MojoExecutionException 
+     * @throws MojoExecutionException
      * @return an instance of an ElasticsearchNode
      */
     public static ElasticsearchNode start(String dataPath, int httpPort, int tcpPort)
@@ -75,8 +89,8 @@ public class ElasticsearchNode
         // ES v2.0.0 requires the path.home property.
         // Set it to the parent of the data directory.
         String homePath = new File(dataPath).getParent();
-        
-        Settings settings = Settings.settingsBuilder()
+
+        Settings settings = Settings.builder()
                 .put("cluster.name", "test")
                 .put("action.auto_create_index", false)
                 .put("transport.tcp.port", tcpPort)
@@ -84,7 +98,55 @@ public class ElasticsearchNode
                 .put("path.data", dataPath)
                 .put("path.home", homePath)
                 .build();
-        return new ElasticsearchNode(settings);
+
+        return start(settings);
+    }
+
+    /**
+     * Start a local ES node with the given settings.
+     * <br>
+     * If the local node is already running prior to calling this method,
+     * an IllegalStateException will be thrown.
+     * @param settings
+     * @throws MojoExecutionException
+     */
+    public static ElasticsearchNode start(Settings settings)
+            throws MojoExecutionException
+    {
+    	settings = Settings.builder()
+                .put("network.host", "127.0.0.1")
+                .put("http.cors.enabled", true)
+                .put("discovery.zen.fd.ping_timeout", "3ms")
+                .put(settings)
+                .build();
+        // Must use this internal API to get ES to load the configuration files...
+    	Environment environment = InternalSettingsPreparer.prepareEnvironment( settings, Terminal.DEFAULT );
+        setupLogging(environment);
+        return new ElasticsearchNode(environment);
+    }
+
+    /**
+     * Copied from org.elasticsearch.bootstrap.Bootstrap.
+     * @param settings
+     */
+    private static void setupLogging(Environment environment)
+    {
+        LogConfigurator.configureWithoutConfig( environment.settings() );
+        try
+        {
+            Class.forName("org.apache.logging.log4j.Logger");
+            LogConfigurator.configure( environment );
+        } catch (ClassNotFoundException e)
+        {
+            // no log4j
+        } catch (NoClassDefFoundError e)
+        {
+            // no log4j
+        } catch (Exception e)
+        {
+            System.err.println("Failed to configure logging...");
+            e.printStackTrace();
+        }
     }
 
     /**
@@ -95,13 +157,15 @@ public class ElasticsearchNode
     {
         return node.client();
     }
-    
+
     /**
      * Close the ES node.
      * <br>
      * If the node is already stopped or closed, this method is a no-op.
+     *
+     * @throws IOException
      */
-    public void stop()
+    public void stop() throws IOException
     {
         if (node != null)
         {

--- a/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/RunElasticsearchNodeMojo.java
+++ b/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/RunElasticsearchNodeMojo.java
@@ -3,6 +3,7 @@ package com.github.alexcojocaru.mojo.elasticsearch;
 import org.apache.maven.plugin.MojoExecutionException;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -38,8 +39,13 @@ public class RunElasticsearchNodeMojo extends StartElasticsearchNodeMojo {
 
             //Adding shutdown hook to stop ES
             Runtime.getRuntime().addShutdownHook(new Thread() {
+                @Override
                 public void run() {
-                    esearchNode.stop();
+                    try {
+                        esearchNode.stop();
+                    } catch (IOException e) {
+                        getLog().error("RunElasticsearchNodeMojo failed to send a stop command to ES instance", e);
+                    }
                     waitES.countDown();
                 }
             });

--- a/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/StopElasticsearchNodeMojo.java
+++ b/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/StopElasticsearchNodeMojo.java
@@ -1,5 +1,7 @@
 package com.github.alexcojocaru.mojo.elasticsearch;
 
+import java.io.IOException;
+
 import org.apache.maven.plugin.MojoExecutionException;
 
 /**
@@ -17,7 +19,11 @@ public class StopElasticsearchNodeMojo extends AbstractElasticsearchNodeMojo
     {
         if (getNode() != null )
         {
-            getNode().stop();
+            try {
+                getNode().stop();
+            } catch (IOException e) {
+                throw new MojoExecutionException( "StopElasticsearchNodeMojo failed to stop the Elasticsearch node", e );
+            }
         }
     }
 }

--- a/src/test/java/com/github/alexcojocaru/mojo/elasticsearch/LoadElasticsearchDataMojoTest.java
+++ b/src/test/java/com/github/alexcojocaru/mojo/elasticsearch/LoadElasticsearchDataMojoTest.java
@@ -9,11 +9,6 @@ import org.apache.maven.plugin.testing.AbstractMojoTestCase;
 import com.github.alexcojocaru.mojo.elasticsearch.NetUtil.ElasticsearchPort;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsRequest;
-import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
-import org.elasticsearch.action.delete.DeleteRequest;
-import org.elasticsearch.action.exists.ExistsRequest;
-import org.elasticsearch.action.get.GetRequest;
-import org.elasticsearch.action.index.IndexRequest;
 
 /**
  * @author alexcojocaru


### PR DESCRIPTION
With the recent release of ES 5.0, an upgrade might be a good idea :)

Here is a first attempt. It's not really polished, but I think it's a good start: it launches the instance and passes the tests.

What's missing (I didn't really look into it):
- A log4j2 example configuration
- A way for users to manage the netty4 plugin version (or we can let them override the dependency, but this should be documented)
- Multicast support? (it's been removed from ES)
- Updating the documentation?

Any chance this can get merged and released? Do you need me to do something else before?

Thanks.
