### PR TITLE
Added possibility to switch off reusing the Node

### DIFF
--- a/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/StartElasticsearchNodeMojo.java
+++ b/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/StartElasticsearchNodeMojo.java
@@ -54,6 +54,11 @@ public class StartElasticsearchNodeMojo extends AbstractElasticsearchNodeMojo {
     protected boolean autoCreateIndex;
 
     /**
+     * @parameter default-value=true
+     */
+    protected boolean reuseElasticNode = true;
+    
+    /**
      * @parameter
      * @required
      */
@@ -105,7 +110,7 @@ public class StartElasticsearchNodeMojo extends AbstractElasticsearchNodeMojo {
 
     protected ElasticsearchNode startNode(Settings settings) throws MojoExecutionException
     {
-        if (getNode() != null)
+        if (reuseElasticNode && getNode() != null)
         {
             return getNode();
         }

--- a/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/StartElasticsearchNodeMojo.java
+++ b/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/StartElasticsearchNodeMojo.java
@@ -52,11 +52,6 @@ public class StartElasticsearchNodeMojo extends AbstractElasticsearchNodeMojo {
      * @parameter default-value=false
      */
     protected boolean autoCreateIndex;
-
-    /**
-     * @parameter default-value=true
-     */
-    protected boolean reuseElasticNode = true;
     
     /**
      * @parameter
@@ -110,7 +105,7 @@ public class StartElasticsearchNodeMojo extends AbstractElasticsearchNodeMojo {
 
     protected ElasticsearchNode startNode(Settings settings) throws MojoExecutionException
     {
-        if (reuseElasticNode && getNode() != null)
+        if (getNode() != null && !getNode().isClosed())
         {
             return getNode();
         }


### PR DESCRIPTION
Our project should run integration tests several times so that we need to reuse the ElasticSearch Node