### PR TITLE
Fix #25 - Redirect subcommands I/O to the parent process, fixing blocking issues

### DIFF
--- a/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/ForkedInstance.java
+++ b/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/ForkedInstance.java
@@ -48,7 +48,7 @@ public class ForkedInstance
 
         ProcessBuilder processBuilder = new ProcessBuilder(getStartScriptCommand());
         processBuilder.directory(baseDir);
-        processBuilder.redirectErrorStream(true);
+        processBuilder.inheritIO();
         
         Log log = config.getClusterConfiguration().getLog();
 
@@ -90,7 +90,7 @@ public class ForkedInstance
 
         ProcessBuilder processBuilder = new ProcessBuilder("chmod", "755", "elasticsearch");
         processBuilder.directory(binDirectory);
-        processBuilder.redirectErrorStream(true);
+        processBuilder.inheritIO();
 
         Log log = config.getClusterConfiguration().getLog();
 


### PR DESCRIPTION
This fix an issue I encountered where the Elasticsearch server would timeout on every single index-related request after a given time. I think this is the same issue as #25.

Explanation below.

By default subcommands' stderr, stdout and stdin are redirected to pipes accessible from  `Process.getErrorStream()`, `Process.getOutputStream()` and `Process.getInputStream()`.

This means in particular that, when subcommands write to stderr and stdout, the writes will be blocking until someone reads from `Process.getErrorStream()` and `Process.getOutputStream()`.

Since we don't, the subcommands used to block as soon as they needed to write to stderr or stdout.

In my case that would result in [this threaddump](https://gist.github.com/yrodiere/2931d4adaba373d02b1e00d597e4f16f), where [thread 22 would be blocking](https://gist.github.com/yrodiere/2931d4adaba373d02b1e00d597e4f16f#file-threaddump-txt-L1141) trying to write a log related to the successful creation of an index, and [subsequent attempts to log would block](https://gist.github.com/yrodiere/2931d4adaba373d02b1e00d597e4f16f#file-threaddump-txt-L1089) because of some synchronized methods in the log machinery (`OutputStreamManager.flush`, `OutputStreamManager.write`, etc.).

I suspect the issue was not obvious because writes to stderr and stdout in Elasticsearch are done through Apache Commons Logs, and those writes are generally buffered, meaning they won't block until the buffer is full.

Regarding the solution, I personally prefer to redirect subcommands I/O to the parent process rather than redirecting subcommands I/O to files, but maybe this should be made configurable? Please tell me, I'll try to add this.