### PR TITLE
Fix the M2E lifecycle mapping to make it possible to build in Eclipse again

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -288,7 +288,7 @@
 									<pluginExecutionFilter>
 										<groupId>org.apache.maven.plugins</groupId>
 										<artifactId>maven-plugin-plugin</artifactId>
-										<version>3.2</version>
+										<versionRange>[3.2,)</versionRange>
 										<goals>
 											<goal>descriptor</goal>
 											<goal>helpmojo</goal>


### PR DESCRIPTION
Lifecycle mappings expect version *range*, not a version. Without this
range, Eclipse (4.6.0) raised the following error message:

	Cannot parse lifecycle mapping metadata for maven project MavenProject:
	com.github.alexcojocaru:elasticsearch-maven-plugin:5.4-SNAPSHOT @
	/OBFUSCATED/elasticsearch-maven-plugin/pom.xml
	Cause: Unrecognised tag: 'version' (position: START_TAG seen
	...</artifactId>\n        <version>... @8:18)