### PR TITLE
Add the pathConf configuration parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ The Elasticsearch behaviour and properties can be configured through the followi
 *   **transportPort** [defaultValue=9300]
     > the port for the Elasticsearch node to node communication; when configuring multiple instances, they will be assigned subsequent transport ports starting with this value (mind the conflicts with the HTTP ports)
 
+*   **pathConf** [defaultValue=""] (note: common to all instances !!!)
+    > the absolute path (or relative to the maven project) of the custom directory containing configuration files, to be copied to Elasticsearch instances
+
 *   **pathData** [defaultValue=""] - work in progress (note: per instance !!!)
     > the custom data directory to configure in Elasticsearch
 

--- a/src/it/runforked-with-path-conf/es-conf/elasticsearch.yml
+++ b/src/it/runforked-with-path-conf/es-conf/elasticsearch.yml
@@ -1,0 +1,2 @@
+# Enable Groovy scripting support for search
+script.engine.groovy.inline.search: on

--- a/src/it/runforked-with-path-conf/pom.xml
+++ b/src/it/runforked-with-path-conf/pom.xml
@@ -1,0 +1,77 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>com.github.alexcojocaru.mojo.elasticsearch.its.ra</groupId>
+	<artifactId>test</artifactId>
+	<version>1.0-SNAPSHOT</version>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+	
+	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.10</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>2.2.17</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.github.alexcojocaru</groupId>
+			<artifactId>elasticsearch-maven-plugin</artifactId>
+			<version>${elasticsearch.maven.plugin.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.github.alexcojocaru</groupId>
+			<artifactId>elasticsearch-maven-plugin</artifactId>
+			<version>${elasticsearch.maven.plugin.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-plugin-api</artifactId>
+			<version>${maven.version}</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>com.github.alexcojocaru</groupId>
+				<artifactId>elasticsearch-maven-plugin</artifactId>
+				<version>@project.version@</version>
+				<configuration>
+				</configuration>
+				<executions>
+					<execution>
+						<id>run</id>
+						<!-- the tests execute in the "test" phase, start ES before that phase -->
+						<phase>process-test-resources</phase>
+						<goals>
+							<goal>runforked</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>stop</id>
+						<phase>post-integration-test</phase>
+						<goals>
+							<goal>stop</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/src/it/runforked-with-path-conf/setup.groovy
+++ b/src/it/runforked-with-path-conf/setup.groovy
@@ -1,0 +1,14 @@
+import com.github.alexcojocaru.mojo.elasticsearch.v2.ItSetup
+
+def instanceCount = 1
+
+// since I cannot pass the props to the maven process directly, save them to the props file;
+// the file is then loaded by the invoker plugin and all props defined in it are set as system props
+
+def setup = new ItSetup(basedir)
+def props = setup.generateProperties(instanceCount)
+props.put("es.pathConf", "es-conf");
+setup.saveProperties("test.properties", props)
+context.putAll(props);
+
+println("Running plugin with properties ${props}")

--- a/src/it/runforked-with-path-conf/src/test/java/com/github/alexcojocaru/mojo/elasticsearch/v2/PathConfTest.java
+++ b/src/it/runforked-with-path-conf/src/test/java/com/github/alexcojocaru/mojo/elasticsearch/v2/PathConfTest.java
@@ -1,0 +1,77 @@
+package com.github.alexcojocaru.mojo.elasticsearch.v2;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.apache.maven.plugin.logging.Log;
+
+import com.github.alexcojocaru.mojo.elasticsearch.v2.client.ElasticsearchClient;
+import com.github.alexcojocaru.mojo.elasticsearch.v2.client.ElasticsearchClientException;
+import com.github.alexcojocaru.mojo.elasticsearch.v2.client.Monitor;
+
+/**
+ *
+ * @author Alex Cojocaru
+ *
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class PathConfTest extends ItBase
+{
+    @Test
+    public void testClusterRunning()
+    {
+        boolean isRunning = Monitor.isClusterRunning(clusterName, client);
+        Assert.assertTrue("The ES cluster should be running", isRunning);
+    }
+
+    @Test
+    public void testScript() throws ElasticsearchClientException
+    {
+        // create index
+        client.put(
+                "/city",
+                "{ \"settings\" : { \"number_of_shards\" : 1, \"number_of_replicas\" : 0 } }");
+
+        // create mapping
+        client.put(
+                "/city/street/_mapping",
+                "{ \"street\" : { \"properties\" : { \"name\" : { \"type\" : \"keyword\" } } } }");
+
+        // index a document
+        client.put("/city/street/1?refresh=true", "{ \"name\" : \"foo\" }");
+
+
+        // la piece de resistance: run an inline groovy script
+        // (which is forbidden by default, but allowed by our config file)
+        Map results = client.get(
+                "/city/street/_search",
+                "{ \"script_fields\": { \"suffixedName\":"
+                + "{ \"script\": { \"lang\": \"groovy\", \"inline\": \"doc['name'][0] + 'bar'\" } }"
+                + "} }",
+                HashMap.class);
+
+        // get the first hit
+        Map hits = (Map) results.get("hits");
+        List hitsArray = (List) hits.get("hits");
+        Map firstHit = (Map) hitsArray.get(0);
+        Map firstHitFields = (Map) firstHit.get("fields");
+
+        // the suffixed name must exist
+        List expected = new ArrayList();
+        expected.add( "foobar" );
+        Assert.assertEquals(expected, firstHitFields.get("suffixedName"));
+    }
+
+}

--- a/src/it/runforked-with-path-conf/verify.groovy
+++ b/src/it/runforked-with-path-conf/verify.groovy
@@ -1,0 +1,17 @@
+import java.io.File
+
+import com.github.alexcojocaru.mojo.elasticsearch.v2.ItVerification
+
+def instanceCount = Integer.parseInt(context.get("es.instanceCount"))
+def clusterName = context.get("es.clusterName")
+def httpPort = Integer.parseInt(context.get("es.httpPort"))
+
+(0..<instanceCount).each {
+    def esBaseDir = new File(new File(basedir, "target"), "elasticsearch" + it)
+    def verification = new ItVerification(esBaseDir)
+
+	verification.verifyBaseDirectoryExists()
+	verification.verifyInstanceNotRunning(clusterName, httpPort)
+}
+
+return true

--- a/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/AbstractElasticsearchMojo.java
+++ b/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/AbstractElasticsearchMojo.java
@@ -68,6 +68,12 @@ public abstract class AbstractElasticsearchMojo
     protected int transportPort;
 
     /**
+     * The path to the configuration directory (containing elasticsearch.yml, log4j2.properties, ...).
+     */
+    @Parameter(property="es.pathConf")
+    protected String pathConf;
+
+    /**
      * The path to the data directory.
      */
     @Parameter(property="es.pathData")
@@ -187,6 +193,16 @@ public abstract class AbstractElasticsearchMojo
         this.transportPort = transportPort;
     }
 
+    public String getPathConf()
+    {
+        return pathConf;
+    }
+
+    public void setPathConf(String pathData)
+    {
+        this.pathConf = pathData;
+    }
+
     public String getPathData()
     {
         return pathData;
@@ -266,8 +282,8 @@ public abstract class AbstractElasticsearchMojo
     {
         this.autoCreateIndex = autoCreateIndex;
     }
-
     
+
     @Override
     public ClusterConfiguration buildClusterConfiguration()
     {
@@ -276,6 +292,7 @@ public abstract class AbstractElasticsearchMojo
                 .withLog(getLog())
                 .withVersion(version)
                 .withClusterName(clusterName)
+                .withPathConf(pathConf)
                 .withPathScripts(pathScripts)
                 .withPathInitScript(pathInitScript)
                 .withKeepExistingData(keepExistingData)

--- a/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/ClusterConfiguration.java
+++ b/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/ClusterConfiguration.java
@@ -23,6 +23,7 @@ public class ClusterConfiguration
 
     private String version;
     private String clusterName;
+    private String pathConf;
     private String pathScripts;
     private String pathInitScript;
     private boolean keepExistingData;
@@ -64,6 +65,11 @@ public class ClusterConfiguration
         return clusterName;
     }
     
+    public String getPathConf()
+    {
+        return pathConf;
+    }
+
     public String getPathScripts()
     {
         return pathScripts;
@@ -99,6 +105,7 @@ public class ClusterConfiguration
         return new ToStringBuilder(this)
                 .append("version", version)
                 .append("clusterName", clusterName)
+                .append("pathConfigFile", pathConf)
                 .append("pathScripts", pathScripts)
                 .append("pathInitScript", pathInitScript)
                 .append("keepExistingData", keepExistingData)
@@ -117,6 +124,7 @@ public class ClusterConfiguration
 
         private String version;
         private String clusterName;
+        private String pathConf;
         private String pathScripts;
         private String pathInitScript;
         private boolean keepExistingData;
@@ -152,6 +160,12 @@ public class ClusterConfiguration
         public Builder withClusterName(String clusterName)
         {
             this.clusterName = clusterName;
+            return this;
+        }
+
+        public Builder withPathConf(String pathConf)
+        {
+            this.pathConf = pathConf;
             return this;
         }
 
@@ -198,6 +212,7 @@ public class ClusterConfiguration
 
             config.version = version;
             config.clusterName = clusterName;
+            config.pathConf = pathConf;
             config.pathScripts = pathScripts;
             config.pathInitScript = pathInitScript;
             config.keepExistingData = keepExistingData;

--- a/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/client/HttpGetWithEntity.java
+++ b/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/client/HttpGetWithEntity.java
@@ -1,0 +1,31 @@
+package com.github.alexcojocaru.mojo.elasticsearch.v2.client;
+
+import java.net.URI;
+
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
+import org.apache.http.client.methods.HttpGet;
+
+/**
+ * @author Yoann Rodiere
+ */
+public class HttpGetWithEntity extends HttpEntityEnclosingRequestBase {
+
+    public HttpGetWithEntity() {
+        super();
+    }
+
+    public HttpGetWithEntity(URI uri) {
+        super();
+        setURI(uri);
+    }
+
+    public HttpGetWithEntity(String uri) {
+        super();
+        setURI(URI.create(uri));
+    }
+
+    @Override
+    public String getMethod() {
+        return HttpGet.METHOD_NAME;
+    }
+}

--- a/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/configuration/ElasticsearchConfiguration.java
+++ b/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/configuration/ElasticsearchConfiguration.java
@@ -16,6 +16,8 @@ public interface ElasticsearchConfiguration extends ElasticsearchBaseConfigurati
     
     int getTransportPort();
     
+    String getPathConf();
+    
     String getPathData();
     
     String getPathLogs();

--- a/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/step/PreStartClusterSequence.java
+++ b/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/step/PreStartClusterSequence.java
@@ -17,6 +17,7 @@ public class PreStartClusterSequence
         add(new ValidateClusterNameStep());
         add(new ValidateUniquePortsStep());
         add(new ValidatePortsStep());
+        add(new ValidatePathConfStep());
         add(new ValidatePathScriptsStep());
     }
 }

--- a/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/step/ResolveElasticsearchStep.java
+++ b/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/step/ResolveElasticsearchStep.java
@@ -40,7 +40,15 @@ public class ResolveElasticsearchStep
                     .resolveArtifact(artifact.getArtifactCoordinates());
             unpackDirectory = getUnpackDirectory();
             ZipUtil.unpack(resolvedArtifact, unpackDirectory);
-            moveToElasticsearchDirectory(unpackDirectory, new File(config.getBaseDir()));
+            File baseDir = new File(config.getBaseDir());
+            moveToElasticsearchDirectory(unpackDirectory, baseDir);
+
+            String pathConf = config.getClusterConfiguration().getPathConf();
+            if (pathConf != null && !pathConf.isEmpty()) {
+                // Merge the user-defined config directory with the default one
+                // This allows user to omit some configuration files (jvm.options for instance)
+                FileUtils.copyDirectory(new File(pathConf), new File(baseDir, "config"));
+            }
         }
         catch (ResolutionException | IOException e)
         {

--- a/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/step/ValidateBaseDirectoryStep.java
+++ b/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/step/ValidateBaseDirectoryStep.java
@@ -30,7 +30,8 @@ public class ValidateBaseDirectoryStep
         catch (Exception e)
         {
             throw new ElasticsearchSetupException(String.format(
-                    "The value of the 'baseDir' parameter is not a valid file path."));
+                    "The value of the 'baseDir' parameter ('%1$s') is not a valid file path.",
+                    baseDir));
         }
     }
 

--- a/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/step/ValidatePathConfStep.java
+++ b/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/step/ValidatePathConfStep.java
@@ -1,0 +1,32 @@
+package com.github.alexcojocaru.mojo.elasticsearch.v2.step;
+
+import java.io.File;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.github.alexcojocaru.mojo.elasticsearch.v2.ClusterConfiguration;
+import com.github.alexcojocaru.mojo.elasticsearch.v2.ElasticsearchSetupException;
+
+/**
+ * Validate that the provided pathConf, if any, points to an existing directory.
+ *
+ * @author Alex Cojocaru
+ */
+public class ValidatePathConfStep
+        implements ClusterStep
+{
+
+    @Override
+    public void execute(ClusterConfiguration config)
+    {
+        String pathConf = config.getPathConf();
+
+        if (StringUtils.isNotBlank(pathConf) && new File(pathConf).isDirectory() == false)
+        {
+            throw new ElasticsearchSetupException(String.format(
+                    "The value of the 'pathConf' parameter must be the absolute path"
+                    + " (or relative to the maven project) of an existing directory."));
+        }
+    }
+
+}

--- a/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/step/ValidatePathConfStep.java
+++ b/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/step/ValidatePathConfStep.java
@@ -24,8 +24,8 @@ public class ValidatePathConfStep
         if (StringUtils.isNotBlank(pathConf) && new File(pathConf).isDirectory() == false)
         {
             throw new ElasticsearchSetupException(String.format(
-                    "The value of the 'pathConf' parameter must be the absolute path"
-                    + " (or relative to the maven project) of an existing directory."));
+                    "The value of the 'pathConf' parameter ('%1$s') must be the absolute path"
+                    + " (or relative to the maven project) of an existing directory.", pathConf));
         }
     }
 

--- a/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/step/ValidatePathScriptsStep.java
+++ b/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/step/ValidatePathScriptsStep.java
@@ -24,8 +24,8 @@ public class ValidatePathScriptsStep
         if (StringUtils.isNotBlank(pathScripts) && new File(pathScripts).isDirectory() == false)
         {
             throw new ElasticsearchSetupException(String.format(
-                    "The value of the 'pathScripts' parameter must be the absolute path"
-                    + " (or relative to the maven project) of an existing directory."));
+                    "The value of the 'pathScripts' parameter ('%1$s') must be the absolute path"
+                    + " (or relative to the maven project) of an existing directory.", pathScripts));
         }
     }
 


### PR DESCRIPTION
This PR adds the "pathConf" configuration parameter, allowing users to provide their own configuration files.
The main limitation is that you can only provide one file per cluster, but it is enough for my use case, which is simply enabling inline scripts.