### PR TITLE
Remove space from `pid` filename

### DIFF
--- a/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/StopMojo.java
+++ b/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/StopMojo.java
@@ -57,7 +57,7 @@ public class StopMojo
         String pid;
         try
         {
-            pid = new String(Files.readAllBytes(Paths.get(basePath, " pid")));
+            pid = new String(Files.readAllBytes(Paths.get(basePath, "pid")));
         }
         catch (IOException e)
         {


### PR DESCRIPTION
Filename that starts with space is not supported, AFAIK