### PR TITLE
Update runforked-defaults-es6 test to Elasticsearch 6.0.0-rc1

### DIFF
--- a/src/it/runforked-defaults-es6/pom.xml
+++ b/src/it/runforked-defaults-es6/pom.xml
@@ -49,7 +49,7 @@
 				<artifactId>elasticsearch-maven-plugin</artifactId>
 				<version>@project.version@</version>
 				<configuration>
-					<version>6.0.0-beta2</version>
+					<version>6.0.0-rc1</version>
 				</configuration>
 				<executions>
 					<execution>


### PR DESCRIPTION
This PR updates the "runforked-defaults-es6" integration test to [Elasticsearch 6.0.0-rc1](https://www.elastic.co/blog/elasticsearch-6-0-0-rc1-released).