### PR TITLE
make sure JAVA_TOOL_OPTIONS and JAVA_OPTS do not fail the build

### DIFF
--- a/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/util/ProcessUtil.java
+++ b/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/util/ProcessUtil.java
@@ -297,20 +297,32 @@ public class ProcessUtil
     {
         Map<String, String> result = null;
         
+        try
+        {
+            result = EnvironmentUtils.getProcEnvironment();
+        }
+        catch (IOException ex)
+        {
+            throw new ElasticsearchSetupException(
+                    "Cannot get the current process environment", ex);
+        }
+
         if (environment != null)
         {
-            try
-            {
-                result = EnvironmentUtils.getProcEnvironment();
-            }
-            catch (IOException ex)
-            {
-                throw new ElasticsearchSetupException(
-                        "Cannot get the current process environment", ex);
-            }
             result.putAll(environment);
         }
-        
+
+        // the elasticsearch start/plugin scripts print warnings if these environment variables are passed
+        // and unsets these. And because the scripts would print a warning, we can't rely on the output :(
+        if(result.containsKey("JAVA_TOOL_OPTIONS"))
+        {
+            result.remove("JAVA_TOOL_OPTIONS");
+        }
+        if(result.containsKey("JAVA_OPTS"))
+        {
+            result.remove("JAVA_OPTS");
+        }
+
         return result;
     }
 

--- a/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/util/ProcessUtil.java
+++ b/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/util/ProcessUtil.java
@@ -314,14 +314,8 @@ public class ProcessUtil
 
         // the elasticsearch start/plugin scripts print warnings if these environment variables are passed
         // and unsets these. And because the scripts would print a warning, we can't rely on the output :(
-        if(result.containsKey("JAVA_TOOL_OPTIONS"))
-        {
-            result.remove("JAVA_TOOL_OPTIONS");
-        }
-        if(result.containsKey("JAVA_OPTS"))
-        {
-            result.remove("JAVA_OPTS");
-        }
+        result.remove("JAVA_TOOL_OPTIONS");
+        result.remove("JAVA_OPTS");
 
         return result;
     }


### PR DESCRIPTION
Elasticsearch start and plugin scripts print a warning in case `JAVA_TOOL_OPTIONS` or `JAVA_OPTS` environment variables are set. This is also described in the [elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/master/jvm-options.html)  and the sources are here available at https://github.com/elastic/elasticsearch/blob/9b9f85e5098f01cd063e54c7058aa49e66afd15d/distribution/src/main/resources/bin/elasticsearch-env#L54 and https://github.com/elastic/elasticsearch/blob/9b9f85e5098f01cd063e54c7058aa49e66afd15d/distribution/src/main/resources/bin/elasticsearch-env#L61

e.g.
```
> export JAVA_TOOL_OPTIONS="-Djava.vendor=Sun"
> ./bin/elasticsearch-plugin list
Warning: Ignoring JAVA_TOOL_OPTIONS=-Djava.vendor=Sun
...
```

This causes issues in the `elasticsearch-maven-plugin`, because the output does not only contain the expected information (e.g. a list of plugins) but also the warning:

```
[INFO] 
[INFO] --- elasticsearch-maven-plugin:6.4-SNAPSHOT-Domi:runforked (start-elasticsearch) @ yooture.elasticsearch ---
[INFO] Using Elasticsearch [0] configuration: com.github.alexcojocaru.mojo.elasticsearch.v2.InstanceConfiguration@6192a5d5[id=0,baseDir=/Users/domi/work/ws/yoo/yooture/yooture.elasticsearch/target/elasticsearch0,httpPort=9200,transportPort=9300,pathData=<null>,pathLogs=<null>,settings=<null>]
[INFO] Elasticsearch[0]: Executing command '[chmod, 755, bin/elasticsearch-plugin]' in directory '/Users/domi/work/ws/yoo/yooture/yooture.elasticsearch/target/elasticsearch0'
[INFO] Elasticsearch[0]: The process finished with exit code 0
[INFO] Elasticsearch[0]: Executing command '[sed, -i, -e, 1s:.*:#!/usr/bin/env bash:, bin/elasticsearch-plugin]' in directory '/Users/domi/work/ws/yoo/yooture/yooture.elasticsearch/target/elasticsearch0'
[INFO] Elasticsearch[0]: The process finished with exit code 0
[INFO] Elasticsearch[0]: Executing command '[bin/elasticsearch-plugin, list]' in directory '/Users/domi/work/ws/yoo/yooture/yooture.elasticsearch/target/elasticsearch0'
Warning: Ignoring JAVA_TOOL_OPTIONS=-Djava.vendor=Sun
[INFO] Elasticsearch[0]: The process finished with exit code 0
[INFO] Removing plugin 'Warning: Ignoring JAVA_TOOL_OPTIONS=-Djava.vendor=Sun'
[INFO] Elasticsearch[0]: Executing command '[bin/elasticsearch-plugin, remove, "Warning: Ignoring JAVA_TOOL_OPTIONS=-Djava.vendor=Sun"]' in directory '/Users/domi/work/ws/yoo/yooture/yooture.elasticsearch/target/elasticsearch0'
Warning: Ignoring JAVA_TOOL_OPTIONS=-Djava.vendor=Sun
-> removing ["Warning: Ignoring JAVA_TOOL_OPTIONS=-Djava.vendor=Sun"]...
ERROR: plugin ["Warning: Ignoring JAVA_TOOL_OPTIONS=-Djava.vendor=Sun"] not found; run 'elasticsearch-plugin list' to get list of installed plugins
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] Yooture ............................................ SUCCESS [  0.612 s]
[INFO] es tests ........................................... FAILURE [  2.125 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 4.548 s
[INFO] Finished at: 2018-01-24T18:22:31+01:00
[INFO] Final Memory: 60M/717M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal com.github.alexcojocaru:elasticsearch-maven-plugin:6.4-SNAPSHOT-Domi:runforked (start-elasticsearch) on project yooture.elasticsearch: Elasticsearch [0]: Cannot execute command '[bin/elasticsearch-plugin, remove, "Warning: Ignoring JAVA_TOOL_OPTIONS=-Djava.vendor=Sun"]' in directory '/Users/domi/work/ws/yoo/yooture/yooture.elasticsearch/target/elasticsearch0'
[ERROR] Output:
[ERROR] Warning: Ignoring JAVA_TOOL_OPTIONS=-Djava.vendor=Sun
[ERROR] -> removing ["Warning: Ignoring JAVA_TOOL_OPTIONS=-Djava.vendor=Sun"]...
[ERROR] ERROR: plugin ["Warning: Ignoring JAVA_TOOL_OPTIONS=-Djava.vendor=Sun"] not found; run 'elasticsearch-plugin list' to get list of installed plugins
[ERROR] Error: Process exited with an error: 78 (Exit value: 78)
[ERROR] -> [Help 1]
[ERROR] 
```

please not: sure setting `JAVA_TOOL_OPTIONS` to `-Djava.vendor=Sun` does not make any sense, but it shows the problem. The origin place where I discovered this issue was when starting the plugin within a Jenkins pipeline job (there also was an other issue reported caused by the same underlying issue: https://issues.jenkins-ci.org/browse/JENKINS-42484 with `JAVA_TOOL_OPTIONS`).

This PR fixes the issue by unsetting the two problematic env variables for the elasticsearch process and therefore make the warning disappear. 

