### PR TITLE
Issue #70 - make elasticsearch-cli executable (ES 6.4.0)

### DIFF
--- a/src/it/runforked-defaults-es640/pom.xml
+++ b/src/it/runforked-defaults-es640/pom.xml
@@ -1,0 +1,75 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>com.github.alexcojocaru.mojo.elasticsearch.its.ra</groupId>
+	<artifactId>test</artifactId>
+	<version>1.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	
+	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.10</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>2.2.17</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.github.alexcojocaru</groupId>
+			<artifactId>elasticsearch-maven-plugin</artifactId>
+			<version>${elasticsearch.maven.plugin.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.github.alexcojocaru</groupId>
+			<artifactId>elasticsearch-maven-plugin</artifactId>
+			<version>${elasticsearch.maven.plugin.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-plugin-api</artifactId>
+			<version>${maven.version}</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>com.github.alexcojocaru</groupId>
+				<artifactId>elasticsearch-maven-plugin</artifactId>
+				<version>@project.version@</version>
+				<configuration>
+					<version>6.4.0</version>
+				</configuration>
+				<executions>
+					<execution>
+						<id>run</id>
+						<!-- the tests execute in the "test" phase, start ES before that phase -->
+						<phase>process-test-resources</phase>
+						<goals>
+							<goal>runforked</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>stop</id>
+						<phase>post-integration-test</phase>
+						<goals>
+							<goal>stop</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/src/it/runforked-defaults-es640/setup.groovy
+++ b/src/it/runforked-defaults-es640/setup.groovy
@@ -1,0 +1,13 @@
+import com.github.alexcojocaru.mojo.elasticsearch.v2.ItSetup
+
+def instanceCount = 1
+
+// since I cannot pass the props to the maven process directly, save them to the props file;
+// the file is then loaded by the invoker plugin and all props defined in it are set as system props
+
+def setup = new ItSetup(basedir)
+def props = setup.generateProperties(instanceCount)
+setup.saveProperties("test.properties", props)
+context.putAll(props);
+
+println("Running plugin with properties ${props}")

--- a/src/it/runforked-defaults-es640/src/test/java/com/github/alexcojocaru/mojo/elasticsearch/v2/DefaultsTest.java
+++ b/src/it/runforked-defaults-es640/src/test/java/com/github/alexcojocaru/mojo/elasticsearch/v2/DefaultsTest.java
@@ -1,0 +1,77 @@
+package com.github.alexcojocaru.mojo.elasticsearch.v2;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.github.alexcojocaru.mojo.elasticsearch.v2.client.ElasticsearchClientException;
+import com.github.alexcojocaru.mojo.elasticsearch.v2.client.Monitor;
+
+/**
+ * 
+ * @author Alex Cojocaru
+ *
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultsTest extends ItBase
+{
+    
+    @Test
+    public void testClusterRunning()
+    {
+        boolean isRunning = Monitor.isClusterRunning(clusterName, instanceCount, client);
+        Assert.assertTrue("The ES cluster should be running", isRunning);
+    }
+    
+    @Test
+    public void testAutoCreateIndex() throws ElasticsearchClientException
+    {
+        // create a document in a new (non-existing) index
+        client.put("/auto_test_index/test_type/1?refresh=true", "{ \"name\" : \"alexc\" }");
+        
+        Map index = client.get("/auto_test_index", HashMap.class);
+        Assert.assertTrue(index.containsKey("auto_test_index"));
+    
+        Map user = client.get("/auto_test_index/test_type/1", HashMap.class);
+
+        // the user must exist
+        Assert.assertEquals(Boolean.TRUE, user.get("found"));
+        
+        // verify the user attributes
+        Map userData = (Map)user.get("_source");
+        Assert.assertEquals("alexc", userData.get("name"));
+    }
+
+    @Test
+    public void testVersion() throws ElasticsearchClientException
+    {
+        // Fetch root resource which includes the version
+        Map root = client.get("/", HashMap.class);
+
+        Map version = (Map) root.get("version");
+        Assert.assertTrue(version.containsKey("number"));
+
+        // verify the major version
+        String versionNumber = (String)version.get("number");
+        Assert.assertTrue(versionNumber.equals("6.4.0"));
+    }
+
+    @Test
+    public void testFlavour() throws ElasticsearchClientException
+    {
+        // Fetch root resource which includes the version
+        Map root = client.get("/", HashMap.class);
+
+        Map version = (Map) root.get("version");
+
+        Assert.assertTrue(version.containsKey("build_flavor"));
+
+        // verify the flavour
+        String flavour = (String)version.get("build_flavor");
+        Assert.assertTrue(flavour.equals("oss"));
+    }
+}

--- a/src/it/runforked-defaults-es640/verify.groovy
+++ b/src/it/runforked-defaults-es640/verify.groovy
@@ -1,0 +1,17 @@
+import java.io.File
+
+import com.github.alexcojocaru.mojo.elasticsearch.v2.ItVerification
+
+def instanceCount = Integer.parseInt(context.get("es.instanceCount"))
+def clusterName = context.get("es.clusterName")
+def httpPort = Integer.parseInt(context.get("es.httpPort"))
+
+(0..<instanceCount).each {
+    def esBaseDir = new File(new File(basedir, "target"), "elasticsearch" + it)
+    def verification = new ItVerification(esBaseDir)
+
+	verification.verifyBaseDirectoryExists()
+	verification.verifyInstanceNotRunning(clusterName, httpPort)
+}
+
+return true

--- a/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/step/InstallPluginsStep.java
+++ b/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/step/InstallPluginsStep.java
@@ -3,6 +3,7 @@ package com.github.alexcojocaru.mojo.elasticsearch.v2.step;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.github.alexcojocaru.mojo.elasticsearch.v2.util.VersionUtil;
 import org.apache.commons.exec.CommandLine;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.plugin.logging.Log;
@@ -25,6 +26,9 @@ public class InstallPluginsStep
     {
         if (config.getClusterConfiguration().getPlugins().size() > 0)
         {
+            if(VersionUtil.isEqualOrGreater_6_4_0(config.getClusterConfiguration().getVersion())) {
+                FilesystemUtil.setScriptPermission(config, "elasticsearch-cli");
+            }
             FilesystemUtil.setScriptPermission(config, "elasticsearch-plugin");
         }
 

--- a/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/step/RemovePluginsStep.java
+++ b/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/step/RemovePluginsStep.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.github.alexcojocaru.mojo.elasticsearch.v2.util.VersionUtil;
 import org.apache.commons.exec.CommandLine;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.plugin.logging.Log;
@@ -48,6 +49,9 @@ public class RemovePluginsStep
         {
             log.debug("The plugins directory exists; removing all installed plugins");
 
+            if(VersionUtil.isEqualOrGreater_6_4_0(config.getClusterConfiguration().getVersion())) {
+                FilesystemUtil.setScriptPermission(config, "elasticsearch-cli");
+            }
             FilesystemUtil.setScriptPermission(config, "elasticsearch-plugin");
 
             CommandLine cmd = ProcessUtil.buildCommandLine("bin/elasticsearch-plugin")

--- a/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/util/VersionUtil.java
+++ b/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/util/VersionUtil.java
@@ -11,4 +11,8 @@ public class VersionUtil {
         return version.matches("5\\..*") || version.matches("6\\.[0-2]\\..*");
     }
 
+    public static boolean isEqualOrGreater_6_4_0(String version) {
+        return version.matches("6\\.[4-9]\\..*") || version.matches("[7-9]\\..*")  ;
+    }
+
 }

--- a/src/test/java/com/github/alexcojocaru/mojo/elasticsearch/v2/util/VersionUtilTest.java
+++ b/src/test/java/com/github/alexcojocaru/mojo/elasticsearch/v2/util/VersionUtilTest.java
@@ -35,4 +35,18 @@ public class VersionUtilTest {
         assertFalse(VersionUtil.isBetween_5_0_0_and_6_2_x("7.1.0"));
     }
 
+    @Test
+    public void testIsEqualOrGreater_6_4_0()
+    {
+        assertTrue(VersionUtil.isEqualOrGreater_6_4_0("6.4.0"));
+        assertTrue(VersionUtil.isEqualOrGreater_6_4_0("6.4.1"));
+        assertTrue(VersionUtil.isEqualOrGreater_6_4_0("6.5.0"));
+        assertTrue(VersionUtil.isEqualOrGreater_6_4_0("7.0.0"));
+
+        assertFalse(VersionUtil.isEqualOrGreater_6_4_0("6.3.1"));
+        assertFalse(VersionUtil.isEqualOrGreater_6_4_0("6.3.0"));
+        assertFalse(VersionUtil.isEqualOrGreater_6_4_0("6.0.0"));
+        assertFalse(VersionUtil.isEqualOrGreater_6_4_0("5.1.1"));
+    }
+
 }


### PR DESCRIPTION
With Elasticsearch 6.4.0 the plugin is failing with the error:

`[INFO] Elasticsearch[0]: Executing command '[bin/elasticsearch-plugin, list]' in directory '/home/travis/build/kizombaDev/EventStudio/event-common/target/elasticsearch0' bin/elasticsearch-plugin: line 3: bin/elasticsearch-cli: Permission denied`

This change makes the elasticsearch-cli executable