### PR TITLE
Allow to configure the environment variables passed to Elasticsearch instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ The Elasticsearch behaviour and properties can be configured through the followi
 *   **pathConf** [defaultValue=""] (note: common to all instances !!!)
     > the absolute path (or relative to the maven project) of the custom directory containing configuration files, to be copied to Elasticsearch instances
 
+*   **environmentVariables** [defaultValue=""]
+    > the environment variables to set before starting each Elasticsearch instance (see the [Environment variables](#environmentVariables) section for details) 
+
 *   **pathData** [defaultValue=""] - work in progress (note: per instance !!!); while support for this is being implemented, use `pathConf` to configure this option
     > the custom data directory to configure in Elasticsearch
 
@@ -113,6 +116,37 @@ To use the plugin, include the following in your _pom.xml_ file and modify the c
 </plugin>
 ```
 
+## <a name="environmentVariables"></a>Environment variables
+The environment variables to set before starting each Elasticsearch instance.
+
+Environment variables
+[may be referenced from the Elasticsearch configuration](https://www.elastic.co/guide/en/elasticsearch/reference/current/settings.html#_environment_variable_substitution),
+but the main use case for defining environment variables is to set `JAVA_HOME`,
+so that Elasticsearch is run with a different JDK than the one used to run Maven.
+
+The way to define environment variables is as follows:
+
+```xml
+<plugin>
+    <groupId>com.github.alexcojocaru</groupId>
+    <artifactId>elasticsearch-maven-plugin</artifactId>
+    <version>6.0</version>
+    <configuration>
+        <clusterName>test</clusterName>
+        <transportPort>9300</transportPort>
+        <httpPort>9200</httpPort>
+        ...
+        <environmentVariables>
+            <SOME_CUSTOM_VARIABLE>somevalue</SOME_CUSTOM_VARIABLE>
+            <JAVA_HOME>${path-to-java-home-configured-through-maven-profiles}</JAVA_HOME>
+        </environmentVariables>
+        ...
+    </configuration>
+    <executions>
+        ...
+    </executions>
+</plugin>
+```
 
 ## <a name="plugins"></a>Plugins
 A list of Elasticsearch plugins can be provided to the elasticsearch-maven-plugin.

--- a/src/it/runforked-with-environment-variables/es-conf/elasticsearch.yml
+++ b/src/it/runforked-with-environment-variables/es-conf/elasticsearch.yml
@@ -1,0 +1,1 @@
+node.name: ${NODE_NAME_ENVIRONMENT_VARIABLE}

--- a/src/it/runforked-with-environment-variables/pom.xml
+++ b/src/it/runforked-with-environment-variables/pom.xml
@@ -1,0 +1,80 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>com.github.alexcojocaru.mojo.elasticsearch.its.ra</groupId>
+	<artifactId>test</artifactId>
+	<version>1.0-SNAPSHOT</version>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.10</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>2.2.17</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.github.alexcojocaru</groupId>
+			<artifactId>elasticsearch-maven-plugin</artifactId>
+			<version>${elasticsearch.maven.plugin.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.github.alexcojocaru</groupId>
+			<artifactId>elasticsearch-maven-plugin</artifactId>
+			<version>${elasticsearch.maven.plugin.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-plugin-api</artifactId>
+			<version>${maven.version}</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>com.github.alexcojocaru</groupId>
+				<artifactId>elasticsearch-maven-plugin</artifactId>
+				<version>@project.version@</version>
+				<configuration>
+					<environmentVariables>
+						<NODE_NAME_ENVIRONMENT_VARIABLE>name-defined-in-pom</NODE_NAME_ENVIRONMENT_VARIABLE>
+					</environmentVariables>
+				</configuration>
+				<executions>
+					<execution>
+						<id>run</id>
+						<!-- the tests execute in the "test" phase, start ES before that phase -->
+						<phase>process-test-resources</phase>
+						<goals>
+							<goal>runforked</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>stop</id>
+						<phase>post-integration-test</phase>
+						<goals>
+							<goal>stop</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/src/it/runforked-with-environment-variables/setup.groovy
+++ b/src/it/runforked-with-environment-variables/setup.groovy
@@ -1,0 +1,14 @@
+import com.github.alexcojocaru.mojo.elasticsearch.v2.ItSetup
+
+def instanceCount = 1
+
+// since I cannot pass the props to the maven process directly, save them to the props file;
+// the file is then loaded by the invoker plugin and all props defined in it are set as system props
+
+def setup = new ItSetup(basedir)
+def props = setup.generateProperties(instanceCount)
+props.put("es.pathConf", "es-conf");
+setup.saveProperties("test.properties", props)
+context.putAll(props);
+
+println("Running plugin with properties ${props}")

--- a/src/it/runforked-with-environment-variables/src/test/java/com/github/alexcojocaru/mojo/elasticsearch/v2/EnvConfTest.java
+++ b/src/it/runforked-with-environment-variables/src/test/java/com/github/alexcojocaru/mojo/elasticsearch/v2/EnvConfTest.java
@@ -1,0 +1,48 @@
+package com.github.alexcojocaru.mojo.elasticsearch.v2;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.apache.maven.plugin.logging.Log;
+
+import com.github.alexcojocaru.mojo.elasticsearch.v2.client.ElasticsearchClient;
+import com.github.alexcojocaru.mojo.elasticsearch.v2.client.ElasticsearchClientException;
+import com.github.alexcojocaru.mojo.elasticsearch.v2.client.Monitor;
+
+/**
+ *
+ * @author Alex Cojocaru
+ *
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class EnvConfTest extends ItBase
+{
+    @Test
+    public void testClusterRunning()
+    {
+        boolean isRunning = Monitor.isClusterRunning(clusterName, instanceCount, client);
+        Assert.assertTrue("The ES cluster should be running", isRunning);
+    }
+
+    @Test
+    public void testNodeName() throws ElasticsearchClientException
+    {
+        // Fetch the Elasticsearch root resource which includes the node name
+        Map results = client.get("/", HashMap.class);
+
+        Assert.assertEquals("name-defined-in-pom", results.get("name"));
+    }
+
+}

--- a/src/it/runforked-with-environment-variables/verify.groovy
+++ b/src/it/runforked-with-environment-variables/verify.groovy
@@ -1,0 +1,17 @@
+import java.io.File
+
+import com.github.alexcojocaru.mojo.elasticsearch.v2.ItVerification
+
+def instanceCount = Integer.parseInt(context.get("es.instanceCount"))
+def clusterName = context.get("es.clusterName")
+def httpPort = Integer.parseInt(context.get("es.httpPort"))
+
+(0..<instanceCount).each {
+    def esBaseDir = new File(new File(basedir, "target"), "elasticsearch" + it)
+    def verification = new ItVerification(esBaseDir)
+
+	verification.verifyBaseDirectoryExists()
+	verification.verifyInstanceNotRunning(clusterName, httpPort)
+}
+
+return true

--- a/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/AbstractElasticsearchMojo.java
+++ b/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/AbstractElasticsearchMojo.java
@@ -1,7 +1,9 @@
 package com.github.alexcojocaru.mojo.elasticsearch.v2;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 import org.apache.maven.plugins.annotations.Component;
@@ -118,6 +120,13 @@ public abstract class AbstractElasticsearchMojo
      */
     @Parameter(property="es.pathInitScript")
     protected String pathInitScript;
+
+    /**
+     * Custom environment variables, to be set before launching an instance.
+     * Allows to set `JAVA_HOME` in particular.
+     */
+    @Parameter
+    protected Map<String, String> environmentVariables = new HashMap<>();
 
     /**
      * Whether to keep existing data (data and logs directories).
@@ -349,6 +358,7 @@ public abstract class AbstractElasticsearchMojo
                     .withTransportPort(transportPort + i)
                     .withPathData(pathData)
                     .withPathLogs(pathLogs)
+                    .withEnvironmentVariables(environmentVariables)
                     .withSettings(settings)
                     .build());
         }

--- a/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/ForkedInstance.java
+++ b/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/ForkedInstance.java
@@ -39,7 +39,7 @@ public class ForkedInstance
 
         ProcessUtil.executeScript(config,
                 getStartScriptCommand(),
-                null,
+                config.getEnvironmentVariables(),
                 new ForkedElasticsearchProcessDestroyer(config));
     }
 

--- a/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/InstanceConfiguration.java
+++ b/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/InstanceConfiguration.java
@@ -1,5 +1,6 @@
 package com.github.alexcojocaru.mojo.elasticsearch.v2;
 
+import java.util.Map;
 import java.util.Properties;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -19,6 +20,7 @@ public class InstanceConfiguration
     private int transportPort;
     private String pathData;
     private String pathLogs;
+    private Map<String, String> environmentVariables;
     private Properties settings;
 
 
@@ -62,6 +64,10 @@ public class InstanceConfiguration
         return pathLogs;
     }
 
+    public Map<String, String> getEnvironmentVariables() {
+        return environmentVariables;
+    }
+
     public Properties getSettings()
     {
         return settings;
@@ -89,6 +95,7 @@ public class InstanceConfiguration
         private int transportPort;
         private String pathData;
         private String pathLogs;
+        private Map<String, String> environmentVariables;
         private Properties settings;
         
 
@@ -134,6 +141,11 @@ public class InstanceConfiguration
             return this;
         }
 
+        public Builder withEnvironmentVariables(final Map<String, String> environmentVariables) {
+            this.environmentVariables = environmentVariables;
+            return this;
+        }
+
         public Builder withSettings(final Properties settings) {
             this.settings = settings;
             return this;
@@ -150,6 +162,7 @@ public class InstanceConfiguration
             config.transportPort = transportPort;
             config.pathData = pathData;
             config.pathLogs = pathLogs;
+            config.environmentVariables = environmentVariables;
             config.settings = settings;
 
             return config;


### PR DESCRIPTION
My use case: I'm the maintainer of a library, [Hibernate Search](https://github.com/hibernate/hibernate-search/), and I need to test my library, and my whole build, against JDK13. But Elasticsearch does not work with JDK13 yet. So I need to run Elasticsearch with a JDK that is different from the one used by Maven.

The only option I could find to specify which JDK to use when starting Elasticsearch was to set the `JAVA_HOME` environment variable. So here is a patch that allows `elasticsearch-maven-plugin` users to set environment variables before starting Elasticsearch.

That could theoretically be useful for other use cases, such as leaving variables in the Elasticsearch configuration file. That's how I tested the feature, but personally I don't really need that.