### PR TITLE
Add support for Elasticsearch 7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,11 @@
 			<version>1.10</version>
 		</dependency>
 		<dependency>
+			<groupId>org.codehaus.plexus</groupId>
+			<artifactId>plexus-archiver</artifactId>
+			<version>3.5</version>
+		</dependency>
+		<dependency>
 			<groupId>org.awaitility</groupId>
 			<artifactId>awaitility</artifactId>
 			<version>2.0.0</version>

--- a/src/it/runforked-defaults-es700beta1/pom.xml
+++ b/src/it/runforked-defaults-es700beta1/pom.xml
@@ -1,0 +1,75 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>com.github.alexcojocaru.mojo.elasticsearch.its.ra</groupId>
+	<artifactId>test</artifactId>
+	<version>1.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	
+	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.10</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>2.2.17</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.github.alexcojocaru</groupId>
+			<artifactId>elasticsearch-maven-plugin</artifactId>
+			<version>${elasticsearch.maven.plugin.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.github.alexcojocaru</groupId>
+			<artifactId>elasticsearch-maven-plugin</artifactId>
+			<version>${elasticsearch.maven.plugin.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-plugin-api</artifactId>
+			<version>${maven.version}</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>com.github.alexcojocaru</groupId>
+				<artifactId>elasticsearch-maven-plugin</artifactId>
+				<version>@project.version@</version>
+				<configuration>
+					<version>7.0.0-beta1</version>
+				</configuration>
+				<executions>
+					<execution>
+						<id>run</id>
+						<!-- the tests execute in the "test" phase, start ES before that phase -->
+						<phase>process-test-resources</phase>
+						<goals>
+							<goal>runforked</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>stop</id>
+						<phase>post-integration-test</phase>
+						<goals>
+							<goal>stop</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/src/it/runforked-defaults-es700beta1/setup.groovy
+++ b/src/it/runforked-defaults-es700beta1/setup.groovy
@@ -1,0 +1,13 @@
+import com.github.alexcojocaru.mojo.elasticsearch.v2.ItSetup
+
+def instanceCount = 1
+
+// since I cannot pass the props to the maven process directly, save them to the props file;
+// the file is then loaded by the invoker plugin and all props defined in it are set as system props
+
+def setup = new ItSetup(basedir)
+def props = setup.generateProperties(instanceCount)
+setup.saveProperties("test.properties", props)
+context.putAll(props);
+
+println("Running plugin with properties ${props}")

--- a/src/it/runforked-defaults-es700beta1/src/test/java/com/github/alexcojocaru/mojo/elasticsearch/v2/DefaultsTest.java
+++ b/src/it/runforked-defaults-es700beta1/src/test/java/com/github/alexcojocaru/mojo/elasticsearch/v2/DefaultsTest.java
@@ -1,0 +1,43 @@
+package com.github.alexcojocaru.mojo.elasticsearch.v2;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.github.alexcojocaru.mojo.elasticsearch.v2.client.ElasticsearchClientException;
+import com.github.alexcojocaru.mojo.elasticsearch.v2.client.Monitor;
+
+/**
+ * 
+ * @author Alex Cojocaru
+ *
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultsTest extends ItBase
+{
+    
+    @Test
+    public void testClusterRunning()
+    {
+        boolean isRunning = Monitor.isClusterRunning(clusterName, instanceCount, client);
+        Assert.assertTrue("The ES cluster should be running", isRunning);
+    }
+
+    @Test
+    public void testVersion() throws ElasticsearchClientException
+    {
+        // Fetch root resource which includes the version
+        Map root = client.get("/", HashMap.class);
+
+        Map version = (Map) root.get("version");
+        Assert.assertTrue(version.containsKey("number"));
+
+        // verify the major version
+        String versionNumber = (String)version.get("number");
+        Assert.assertTrue(versionNumber.equals("7.0.0-beta1"));
+    }
+}

--- a/src/it/runforked-defaults-es700beta1/verify.groovy
+++ b/src/it/runforked-defaults-es700beta1/verify.groovy
@@ -1,0 +1,17 @@
+import java.io.File
+
+import com.github.alexcojocaru.mojo.elasticsearch.v2.ItVerification
+
+def instanceCount = Integer.parseInt(context.get("es.instanceCount"))
+def clusterName = context.get("es.clusterName")
+def httpPort = Integer.parseInt(context.get("es.httpPort"))
+
+(0..<instanceCount).each {
+    def esBaseDir = new File(new File(basedir, "target"), "elasticsearch" + it)
+    def verification = new ItVerification(esBaseDir)
+
+	verification.verifyBaseDirectoryExists()
+	verification.verifyInstanceNotRunning(clusterName, httpPort)
+}
+
+return true

--- a/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/ElasticsearchArtifact.java
+++ b/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/ElasticsearchArtifact.java
@@ -7,26 +7,20 @@ public class ElasticsearchArtifact
         extends AbstractArtifact
 {
     public static final String ELASTICSEARCH_GROUPID = "com.github.alexcojocaru";
-    public static final String ELASTICSEARCH_TYPE = "zip";
-
-    public ElasticsearchArtifact(final String artifactId, final String version)
-    {
-        this(ELASTICSEARCH_GROUPID, artifactId, version, ELASTICSEARCH_TYPE);
-    }
 
     public ElasticsearchArtifact(
-            final String groupId,
             final String artifactId,
             final String version,
+            final String classifier,
             final String type)
     {
-        super(groupId, artifactId, version, null, type);
+        super(ELASTICSEARCH_GROUPID, artifactId, version, classifier, type);
     }
 
     @Override
     public String getType()
     {
-        return ELASTICSEARCH_TYPE;
+        return type;
     }
 
     @Override

--- a/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/step/ResolveElasticsearchStep.java
+++ b/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/step/ResolveElasticsearchStep.java
@@ -198,7 +198,7 @@ public class ResolveElasticsearchStep
         });
 
         // should only be one
-        FileUtils.copyDirectory(files[0], dest);
+        FilesystemUtil.copyRecursively(files[0].toPath(), dest.toPath());
     }
 
     protected File getUnpackDirectory()

--- a/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/step/ResolveElasticsearchStep.java
+++ b/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/step/ResolveElasticsearchStep.java
@@ -6,9 +6,11 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.UUID;
 
+import com.github.alexcojocaru.mojo.elasticsearch.v2.util.ArchiveUtil;
+import com.google.common.base.Joiner;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.zeroturnaround.zip.ZipUtil;
+import org.apache.commons.lang3.SystemUtils;
 
 import com.github.alexcojocaru.mojo.elasticsearch.v2.ClusterConfiguration;
 import com.github.alexcojocaru.mojo.elasticsearch.v2.ElasticsearchArtifact;
@@ -26,7 +28,6 @@ import com.github.alexcojocaru.mojo.elasticsearch.v2.util.VersionUtil;
 public class ResolveElasticsearchStep
         implements InstanceStep
 {
-    private final String ELASTICSEARCH_FILENAME = "%s-%s.zip";
     private final String ELASTICSEARCH_DOWNLOAD_URL =
             "https://artifacts.elastic.co/downloads/elasticsearch/%s";
     
@@ -61,8 +62,10 @@ public class ResolveElasticsearchStep
         String flavour = config.getFlavour();
         String version = config.getVersion();
         String artifactId = getArtifactId(flavour, version);
+        String classifier = getArtifactClassifier(version);
+        String type = getArtifactType(version);
 
-        ElasticsearchArtifact artifactReference = new ElasticsearchArtifact(artifactId, version);
+        ElasticsearchArtifact artifactReference = new ElasticsearchArtifact(artifactId, version, classifier, type);
         config.getLog().debug("Artifact ref: " + artifactReference);
 
         PluginArtifactResolver artifactResolver = config.getArtifactResolver();
@@ -113,6 +116,58 @@ public class ResolveElasticsearchStep
         }
     }
 
+    private String getArtifactClassifier(String version)
+    {
+        if (VersionUtil.isEqualOrGreater_7_0_0(version))
+        {
+            if (SystemUtils.IS_OS_WINDOWS)
+            {
+                return "windows-x86_64";
+            }
+            else if (SystemUtils.IS_OS_MAC)
+            {
+                return "darwin-x86_64";
+            }
+            else if (SystemUtils.IS_OS_LINUX)
+            {
+                return "linux-x86_64";
+            }
+            else {
+                throw new IllegalStateException("Unknown OS, cannot determine the Elasticsearch classifier.");
+            }
+        }
+        else // No classifier for ES below 7.0.0
+        {
+            return null;
+        }
+    }
+
+    private String getArtifactType(String version)
+    {
+        if (VersionUtil.isEqualOrGreater_7_0_0(version))
+        {
+            if (SystemUtils.IS_OS_WINDOWS)
+            {
+                return "zip";
+            }
+            else if (SystemUtils.IS_OS_MAC)
+            {
+                return "tar.gz";
+            }
+            else if (SystemUtils.IS_OS_LINUX)
+            {
+                return "tar.gz";
+            }
+            else {
+                throw new IllegalStateException("Unknown OS, cannot determine the Elasticsearch classifier.");
+            }
+        }
+        else // Only a single artifact type below 7.0.0
+        {
+            return "zip";
+        }
+    }
+
     /**
      * Download the artifact from the download repository.
      * @param artifactReference
@@ -125,10 +180,14 @@ public class ResolveElasticsearchStep
             ClusterConfiguration config)
             throws IOException
     {
-        String filename = String.format(
-                ELASTICSEARCH_FILENAME,
-                artifactReference.getArtifactId(),
-                artifactReference.getVersion());
+        String filename = Joiner.on("-").skipNulls()
+                .join(
+                        artifactReference.getArtifactId(),
+                        artifactReference.getVersion(),
+                        artifactReference.getClassifier() // May be null
+                )
+                + "." + artifactReference.getType();
+
         File tempFile = new File(FilesystemUtil.getTempDirectory(), filename);
         tempFile.deleteOnExit();
         FileUtils.deleteQuietly(tempFile);
@@ -179,7 +238,7 @@ public class ResolveElasticsearchStep
             throws IOException
     {
         File unpackDirectory = getUnpackDirectory();
-        ZipUtil.unpack(artifact, unpackDirectory);
+        ArchiveUtil.autodetectAndExtract(artifact, unpackDirectory);
         File baseDir = new File(config.getBaseDir());
         moveToElasticsearchDirectory(unpackDirectory, baseDir);
 

--- a/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/util/ArchiveUtil.java
+++ b/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/util/ArchiveUtil.java
@@ -1,0 +1,46 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package com.github.alexcojocaru.mojo.elasticsearch.v2.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Locale;
+
+import org.codehaus.plexus.archiver.tar.TarGZipUnArchiver;
+import org.codehaus.plexus.logging.console.ConsoleLogger;
+import org.zeroturnaround.zip.ZipUtil;
+
+public class ArchiveUtil {
+
+	public static void autodetectAndExtract(File archiveFile, File targetDir) throws IOException {
+		String filename = archiveFile.toString().toLowerCase(Locale.ROOT);
+		if (filename.endsWith(".zip"))
+		{
+			extractZip(archiveFile, targetDir);
+		}
+		else if (filename.endsWith(".tar.gz"))
+		{
+			extractTarGz(archiveFile, targetDir);
+		}
+		else {
+			throw new IOException("Unsupported archive format for " + archiveFile);
+		}
+	}
+
+	public static void extractZip(File archiveFile, File targetDir) {
+		ZipUtil.unpack(archiveFile, targetDir);
+	}
+
+	public static void extractTarGz(File archiveFile, File targetDir) {
+		TarGZipUnArchiver unArchiver = new TarGZipUnArchiver(archiveFile);
+		unArchiver.setDestDirectory(targetDir);
+		// We don't want logging, but this is necessary to avoid an NPE
+		unArchiver.enableLogging(new ConsoleLogger(ConsoleLogger.LEVEL_DISABLED, "console"));
+		unArchiver.extract();
+	}
+
+}

--- a/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/util/FilesystemUtil.java
+++ b/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/util/FilesystemUtil.java
@@ -87,6 +87,10 @@ public final class FilesystemUtil
             // we do not have file permissions on windows
             return;
         }
+        if (VersionUtil.isEqualOrGreater_7_0_0(config.getClusterConfiguration().getVersion())) {
+            // ES7 and above is packaged as a .tar.gz, and as such the permissions are preserved
+            return;
+        }
         
         CommandLine command = new CommandLine("chmod")
                 .addArgument("755")

--- a/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/util/FilesystemUtil.java
+++ b/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/util/FilesystemUtil.java
@@ -1,6 +1,13 @@
 package com.github.alexcojocaru.mojo.elasticsearch.v2.util;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.commons.exec.CommandLine;
 import org.apache.commons.lang3.SystemUtils;
@@ -38,6 +45,34 @@ public final class FilesystemUtil
     public static File getTempDirectory()
     {
         return new File(System.getProperty("java.io.tmpdir"));
+    }
+
+    /**
+     * Copy a directory recursively, preserving attributes, in particular permissions.
+     */
+    public static void copyRecursively(Path source, Path destination) throws IOException {
+        if (Files.isDirectory(source))
+        {
+            Files.createDirectories(destination);
+            final Set<Path> sources = listFiles(source);
+
+            for (Path srcFile : sources)
+            {
+                Path destFile = destination.resolve(srcFile.getFileName());
+                copyRecursively(srcFile, destFile);
+            }
+        }
+        else
+        {
+            Files.copy(source, destination, StandardCopyOption.COPY_ATTRIBUTES);
+        }
+    }
+
+    private static Set<Path> listFiles(Path directory) throws IOException {
+        try (Stream<Path> stream = Files.list(directory))
+        {
+            return stream.collect(Collectors.toSet());
+        }
     }
 
     /**

--- a/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/util/VersionUtil.java
+++ b/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/util/VersionUtil.java
@@ -18,4 +18,9 @@ public class VersionUtil {
                 || version.matches("([7-9]|(\\d){2,})\\..*");
     }
 
+    public static boolean isEqualOrGreater_7_0_0(String version)
+    {
+        return version.matches("([7-9]|(\\d){2,})\\..*");
+    }
+
 }

--- a/src/test/java/com/github/alexcojocaru/mojo/elasticsearch/v2/util/VersionUtilTest.java
+++ b/src/test/java/com/github/alexcojocaru/mojo/elasticsearch/v2/util/VersionUtilTest.java
@@ -52,4 +52,22 @@ public class VersionUtilTest {
         assertFalse(VersionUtil.isEqualOrGreater_6_4_0("4.11.1"));
     }
 
+    @Test
+    public void testIsEqualOrGreater_7_0_0()
+    {
+        assertTrue(VersionUtil.isEqualOrGreater_7_0_0("7.0.0-beta1"));
+        assertTrue(VersionUtil.isEqualOrGreater_7_0_0("7.0.0"));
+        assertTrue(VersionUtil.isEqualOrGreater_7_0_0("11.2.1"));
+
+        assertFalse(VersionUtil.isEqualOrGreater_7_0_0("6.11.3"));
+        assertFalse(VersionUtil.isEqualOrGreater_7_0_0("6.5.0"));
+        assertFalse(VersionUtil.isEqualOrGreater_7_0_0("6.4.1"));
+        assertFalse(VersionUtil.isEqualOrGreater_7_0_0("6.4.0"));
+        assertFalse(VersionUtil.isEqualOrGreater_7_0_0("6.3.1"));
+        assertFalse(VersionUtil.isEqualOrGreater_7_0_0("6.3.0"));
+        assertFalse(VersionUtil.isEqualOrGreater_7_0_0("6.0.0"));
+        assertFalse(VersionUtil.isEqualOrGreater_7_0_0("5.1.1"));
+        assertFalse(VersionUtil.isEqualOrGreater_7_0_0("4.11.1"));
+    }
+
 }


### PR DESCRIPTION
This makes Elasticsearch-maven-plugin successfully retrieve and run Elasticsearch 7.0.0-beta1 on Linux-x86_64.

I could not test it on Mac or Windows, but since it used not to work at all even on Linux, I guess it can be merged anyway, and once someone manages to test it on Windows/Mac, we can try to debug it?

The PR addresses three main issues:

1. The naming of distribution packages changed in Elasticsearch 7: Linux and Mac packages are now separate from the Windows package, and each package has a suffix in the file name indicating the target OS and architecture.
2. The format of distribution packages changed in Elasticsearch 7: Linux and Mac packages  are provided as `.tar.gz` instead of `.zip`.
3. Elasticsearch 7 requires "executable" permissions on more files.
