### PR TITLE
 Fix FileAlreadyExistsException when executing the plugin twice without an intermediary clean

### DIFF
--- a/src/it/runforked-tworuns/pom.xml
+++ b/src/it/runforked-tworuns/pom.xml
@@ -1,0 +1,99 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>com.github.alexcojocaru.mojo.elasticsearch.its.ra</groupId>
+	<artifactId>test</artifactId>
+	<version>1.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+
+	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.10</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>2.2.17</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.github.alexcojocaru</groupId>
+			<artifactId>elasticsearch-maven-plugin</artifactId>
+			<version>${elasticsearch.maven.plugin.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.github.alexcojocaru</groupId>
+			<artifactId>elasticsearch-maven-plugin</artifactId>
+			<version>${elasticsearch.maven.plugin.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-plugin-api</artifactId>
+			<version>${maven.version}</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>com.github.alexcojocaru</groupId>
+				<artifactId>elasticsearch-maven-plugin</artifactId>
+				<version>@project.version@</version>
+				<configuration>
+				</configuration>
+				<executions>
+					<!--
+					    Simulate a previous run/stop before the actual one, whose created directories were not removed.
+					    Ideally we'd want to run "mvn verify" twice without a "clean",
+					    but that's not easy to do with the current maven-invoker-plugin configuration.
+					 -->
+					<execution>
+						<id>run1</id>
+						<!-- Use a phase before the one used in stop1 -->
+						<phase>process-classes</phase>
+						<goals>
+							<goal>runforked</goal>
+						</goals>
+					</execution>
+					<execution>
+						<!-- Use a phase after the one used in run1 and before the one used in run2 -->
+						<id>stop1</id>
+						<phase>generate-test-sources</phase>
+						<goals>
+							<goal>stop</goal>
+						</goals>
+					</execution>
+					<!--
+					    And perform the second execution, with the tests.
+					    This used to file due to the file copy encountering pre-existing files and aborting.
+					 -->
+					<execution>
+						<id>run2</id>
+						<!-- the tests execute in the "test" phase, start ES before that phase -->
+						<phase>process-test-resources</phase>
+						<goals>
+							<goal>runforked</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>stop2</id>
+						<phase>post-integration-test</phase>
+						<goals>
+							<goal>stop</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/src/it/runforked-tworuns/setup.groovy
+++ b/src/it/runforked-tworuns/setup.groovy
@@ -1,0 +1,13 @@
+import com.github.alexcojocaru.mojo.elasticsearch.v2.ItSetup
+
+def instanceCount = 1
+
+// since I cannot pass the props to the maven process directly, save them to the props file;
+// the file is then loaded by the invoker plugin and all props defined in it are set as system props
+
+def setup = new ItSetup(basedir)
+def props = setup.generateProperties(instanceCount)
+setup.saveProperties("test.properties", props)
+context.putAll(props);
+
+println("Running plugin with properties ${props}")

--- a/src/it/runforked-tworuns/src/test/java/com/github/alexcojocaru/mojo/elasticsearch/v2/DefaultsTest.java
+++ b/src/it/runforked-tworuns/src/test/java/com/github/alexcojocaru/mojo/elasticsearch/v2/DefaultsTest.java
@@ -1,0 +1,30 @@
+package com.github.alexcojocaru.mojo.elasticsearch.v2;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.github.alexcojocaru.mojo.elasticsearch.v2.client.ElasticsearchClientException;
+import com.github.alexcojocaru.mojo.elasticsearch.v2.client.Monitor;
+
+/**
+ * 
+ * @author Alex Cojocaru
+ *
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultsTest extends ItBase
+{
+    
+    @Test
+    public void testClusterRunning()
+    {
+        boolean isRunning = Monitor.isClusterRunning(clusterName, instanceCount, client);
+        Assert.assertTrue("The ES cluster should be running", isRunning);
+    }
+
+}

--- a/src/it/runforked-tworuns/verify.groovy
+++ b/src/it/runforked-tworuns/verify.groovy
@@ -1,0 +1,17 @@
+import java.io.File
+
+import com.github.alexcojocaru.mojo.elasticsearch.v2.ItVerification
+
+def instanceCount = Integer.parseInt(context.get("es.instanceCount"))
+def clusterName = context.get("es.clusterName")
+def httpPort = Integer.parseInt(context.get("es.httpPort"))
+
+(0..<instanceCount).each {
+    def esBaseDir = new File(new File(basedir, "target"), "elasticsearch" + it)
+    def verification = new ItVerification(esBaseDir)
+
+	verification.verifyBaseDirectoryExists()
+	verification.verifyInstanceNotRunning(clusterName, httpPort)
+}
+
+return true

--- a/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/util/FilesystemUtil.java
+++ b/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/util/FilesystemUtil.java
@@ -64,7 +64,7 @@ public final class FilesystemUtil
         }
         else
         {
-            Files.copy(source, destination, StandardCopyOption.COPY_ATTRIBUTES);
+            Files.copy(source, destination, StandardCopyOption.COPY_ATTRIBUTES, StandardCopyOption.REPLACE_EXISTING);
         }
     }
 


### PR DESCRIPTION
#85 introduced a regression: when the plugin is executed twice on the same module without an intermediary "clean", it fails to copy the Elasticsearch files with a `FileAlreadyExistsException`.

It's unlikely to happen in CI builds, but it can happen when developing, and it's rather annoying.

Previously it used to overwrite existing files, and this PR restores that behavior.