### PR TITLE
Set the configured environment variables when running elasticsearch-plugin

### DIFF
--- a/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/InstanceConfiguration.java
+++ b/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/InstanceConfiguration.java
@@ -1,5 +1,6 @@
 package com.github.alexcojocaru.mojo.elasticsearch.v2;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
 
@@ -162,7 +163,7 @@ public class InstanceConfiguration
             config.transportPort = transportPort;
             config.pathData = pathData;
             config.pathLogs = pathLogs;
-            config.environmentVariables = environmentVariables;
+            config.environmentVariables = environmentVariables == null ? Collections.emptyMap() : environmentVariables;
             config.settings = settings;
 
             return config;

--- a/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/step/InstallPluginsStep.java
+++ b/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/step/InstallPluginsStep.java
@@ -41,11 +41,10 @@ public class InstallPluginsStep
                     "Installing plugin '%s' with options '%s'",
                     plugin.getUri(), plugin.getEsJavaOpts()));
             
-            Map<String, String> environment = null;
+            Map<String, String> environment = new HashMap<>(config.getEnvironmentVariables());
             
             if (StringUtils.isNotBlank(plugin.getEsJavaOpts()))
             {
-                environment = new HashMap<>();
                 environment.put("ES_JAVA_OPTS", plugin.getEsJavaOpts());
             }
 

--- a/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/step/RemovePluginsStep.java
+++ b/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/step/RemovePluginsStep.java
@@ -73,7 +73,7 @@ public class RemovePluginsStep
                         .addArgument("remove")
                         .addArgument(pluginName);
                 
-                ProcessUtil.executeScript(config, removeCmd);
+                ProcessUtil.executeScript(config, removeCmd, config.getEnvironmentVariables(), null);
             }
         }
         else


### PR DESCRIPTION
Without this patch, even if I set `JAVA_HOME` explicitly in `environmentVariables` in the plugin configuration, the environment variable is not set when `elasticsearch-plugin` is run.

As a result, `elasticsearch-plugin` gets run with the same JDK as the Maven process, which in my case happens to be JDK8, and consequently I get a warning about ES7 support for JDK8 being deprecated:

```
[INFO] Elasticsearch[0]: Executing command '[bin/elasticsearch-plugin, list]' in directory '/mnt/jenkins-workdir/workspace/arch-personal-yoann_HSEARCH-3653/documentation/target/elasticsearch0'
future versions of Elasticsearch will require Java 11; your Java version from [/mnt/jenkins-workdir/tools/hudson.model.JDK/OpenJDK_8_Latest/jdk8u222-b10/jre] does not meet this requirement
[INFO] Elasticsearch[0]: The process finished with exit code 0
```

This patch solves this problem.