### PR TITLE
Fix ForkedElasticsearchProcessDestroyer issues

### DIFF
--- a/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/ForkedInstance.java
+++ b/src/main/java/com/github/alexcojocaru/mojo/elasticsearch/v2/ForkedInstance.java
@@ -13,7 +13,7 @@ import com.github.alexcojocaru.mojo.elasticsearch.v2.util.ProcessUtil;
 
 /**
  * Start an ES instance and hold the reference to the ES {@link Process}.
- * 
+ *
  * @author Alex Cojocaru
  */
 public class ForkedInstance
@@ -37,10 +37,13 @@ public class ForkedInstance
     {
         FilesystemUtil.setScriptPermission(config, "elasticsearch");
 
+        final ForkedElasticsearchProcessDestroyer processDestroyer = new ForkedElasticsearchProcessDestroyer(config);
+        Runtime.getRuntime().addShutdownHook(new Thread(processDestroyer));
+
         ProcessUtil.executeScript(config,
                 getStartScriptCommand(),
                 config.getEnvironmentVariables(),
-                new ForkedElasticsearchProcessDestroyer(config));
+                processDestroyer);
     }
 
     private InstanceStepSequence getSetupSequence()
@@ -66,7 +69,7 @@ public class ForkedInstance
         		false);
         cmd.addArgument("-Ehttp.port=" + config.getHttpPort(), false);
         cmd.addArgument("-Etransport.tcp.port=" + config.getTransportPort(), false);
-        
+
         // If there are multiple nodes, I need to tell each about the other,
         // in order to form a cluster.
         List<String> hosts = config.getClusterConfiguration().getInstanceConfigurationList()
@@ -84,7 +87,7 @@ public class ForkedInstance
         {
             cmd.addArgument("-Eaction.auto_create_index=false", false);
         }
-        
+
         cmd.addArgument("-Ehttp.cors.enabled=true");
 
         if (config.getSettings() != null)

--- a/src/test/java/com/github/alexcojocaru/mojo/elasticsearch/v2/ForkedElasticsearchProcessDestroyerTest.java
+++ b/src/test/java/com/github/alexcojocaru/mojo/elasticsearch/v2/ForkedElasticsearchProcessDestroyerTest.java
@@ -1,0 +1,47 @@
+package com.github.alexcojocaru.mojo.elasticsearch.v2;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import org.apache.maven.plugin.logging.Log;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ForkedElasticsearchProcessDestroyerTest {
+
+    @Mock
+    private InstanceConfiguration config;
+    @Mock
+    private ClusterConfiguration clusterConfig;
+    @Mock
+    private Log log;
+    @Mock
+    private Process process;
+
+    @Test
+    public void testRemoveDoesNotThrowIllegalStateException() throws InterruptedException, ExecutionException, TimeoutException {
+
+        when(config.getClusterConfiguration()).thenReturn(clusterConfig);
+        when(clusterConfig.getLog()).thenReturn(log);
+        when(process.isAlive()).thenReturn(true);
+
+        final ForkedElasticsearchProcessDestroyer destroyer = new ForkedElasticsearchProcessDestroyer(config);
+        assertEquals("No process added", 0, destroyer.size());
+
+        destroyer.add(process);
+        assertEquals("One process added", 1, destroyer.size());
+
+        destroyer.remove(process);
+        assertEquals("One process removed, but still alive", 1, destroyer.size());
+
+        destroyer.run();
+        assertEquals("Alive process set to null", 0, destroyer.size());
+    }
+
+}


### PR DESCRIPTION
On our Jenkins server we regularly see the following message when the
plugin tries to start the elasticsearch server:
  "This Elasticsearch process destroyer does not support this operation"
This started to happen very frequently after I upgraded to version 6.17
of the plugin. I've seen several similar issues reported, but they're all
closed as resolved. However, since we're still getting this error I had a
look at the code of the ForkedElasticsearchProcessDestroyer.
I do see some issues:
1. The shutdown hook registered in the constructor can throw a
   NullPointerException, because the process can be null.
2. If the DefaultExecutor calls add on the process destroyer then it will
   also call remove on the process destroyer because remove is called
   in a finally block. Based on the stack trace from the Jenkins logging
   I think this is the root cause of my problem.

So the contract for the implementor of ProcessDestroyer seems to be:
   for every process added a call to remove it again will always follow.
Unfortunately this is not very clear from javadoc.  or project documentation.
The solution I chose:
- only throw an IllegalStateException when the process to be removed is not
  equal to the one that was added. This fixes the root cause.
- Let ForkedElasticsearchProcessDestroyer implement Runnable and only call
  terminateProcess() if process is not null. This will prevent the NPEs.

The reason do not I register the shutdown hook in the constructor is to make it
easier to test the implementation of ForkedElasticsearchProcessDestroyer.